### PR TITLE
docs: update Microcks GKE deployment docs with asynchronous options and TLS

### DIFF
--- a/install/gcp/README.md
+++ b/install/gcp/README.md
@@ -1,7 +1,8 @@
 # Deploying Microcks on Google Kubernetes Engine (GKE)
 
 ## Overview
-This guide provides a step-by-step approach to deploying **Microcks** on **Google Kubernetes Engine (GKE)** using **Google Cloud SQL (PostgreSQL)**, **Firestore**, and integrating with **Keycloak** for authentication.
+This guide provides a comprehensive, step-by-step process for deploying **Microcks** on **Google Kubernetes Engine (GKE)**, leveraging **Google Cloud SQL (PostgreSQL)** for database management. It also covers the integration of **External MongoDB** for data storage and **Keycloak** for authentication, enabling a secure and scalable API testing environment in the cloud.
+
 ## Prerequisites
 Before deploying Microcks on GKE, ensure the following tools are installed and configured:
 
@@ -42,7 +43,7 @@ Once billing is enabled, you're ready to proceed with the next steps.
 
 ## 2. Create Service Account and Assign Required Roles
 
-Create a service account for deploying Microcks. Replace `<SERVICE-ACCOUNT-NAME>`, `<SERVICE-ACCOUNT-DESCRIPTION>`, and `<PROJECT-ID>` with your values. For example, the service account name could be `microcks-deployer`, and the project ID could be `microcks333`.
+If you're working in an enterprise or company environment where you don't have access to an admin account, request the admin user to create the service account and grant the following roles. Once the service account is created and the key file (secret) is provided by the admin/root user, you can authenticate and proceed with the setup as the service account.
 
 ```sh
 $ gcloud iam service-accounts create <SERVICE-ACCOUNT-NAME> \
@@ -67,10 +68,6 @@ $ gcloud projects add-iam-policy-binding <PROJECT-ID> \
 
 $ gcloud projects add-iam-policy-binding <PROJECT-ID> \
   --member="serviceAccount:<SERVICE-ACCOUNT-NAME>@<PROJECT-ID>.iam.gserviceaccount.com" \
-  --role="roles/datastore.user"
-
-$ gcloud projects add-iam-policy-binding <PROJECT-ID> \
-  --member="serviceAccount:<SERVICE-ACCOUNT-NAME>@<PROJECT-ID>.iam.gserviceaccount.com" \
   --role="roles/container.developer"
 
 $ gcloud projects add-iam-policy-binding <PROJECT-ID> \
@@ -83,7 +80,7 @@ Generate a key file for the service account. Replace `<PROJECT-ID>` with your ac
 
 ```sh
 $ gcloud iam service-accounts keys create /path/to/microcks-deployer-key.json \
-  --iam-account=microcks-deployer@<PROJECT-ID>.iam.gserviceaccount.com
+  --iam-account=<SERVICE-ACCOUNT-NAME>@<PROJECT-ID>.iam.gserviceaccount.com
 ```
 
 ## 3. Create a GKE Cluster
@@ -118,37 +115,35 @@ $ gcloud container clusters create <CLUSTER-NAME> \
 
 Wait for 7-8 minutes for the cluster to be provisioned and configure node count and disk size based on your usage or team size.
 
-### Authenticate with the Service Account
+> **Note:** If you are deploying Microcks **with asynchronous options enabled**, only then run the following two commands:
 
-Authenticate using the service account.
+```bash
+# Authenticate your local `kubectl` with the GKE cluster
+
+$ gcloud container clusters get-credentials microcks-cluster \
+  --zone us-central1-a \
+  --project microcks123
+
+# Grant cluster-admin permissions to the Microcks deployer service account
+$ kubectl create clusterrolebinding microcks-deployer-admin \
+  --clusterrole=cluster-admin \
+  --user="<SERVICE-ACCOUNT-NAME>@microcks123.iam.gserviceaccount.com"
+```
+
+### Authenticate with the Service Account
 
 ```sh
 $ gcloud auth activate-service-account --key-file=/path/to/microcks-deployer-key.json
 ```
 
-## 4. Enable Firestore API and Create a Firestore Database
-
-### Get Kubernetes Credentials for the Cluster and Verify Kubernetes Access
+### Configure Access to Your GKE Cluster
 
 ```sh
 $ gcloud container clusters get-credentials <CLUSTER-NAME> --zone <CLUSTER-ZONE>
-$ kubectl get nodes
-```
-
-### Set the Project to Ensure the Correct Project is Used
-
-```sh
 $ gcloud config set project <PROJECT-ID>
 ```
 
-### Enable Firestore API and Create Firestore Database in Native Mode
-
-```sh
-$ gcloud services enable firestore.googleapis.com --project=<PROJECT-ID>
-$ gcloud firestore databases create --location=us-central1 --project=<PROJECT-ID>
-```
-
-## 5. Create a Cloud SQL Instance and Database
+## 4. Create a Cloud SQL Instance and Database
 
 ### Create a Cloud SQL Instance
 
@@ -180,7 +175,7 @@ $ gcloud sql users create <USERNAME> \
 
 For example, project ID microcks333, instance name microcks-cloudsql, database name keycloak_db and username keycloak_user.
 
-## 6. Setting Up Private Connectivity Between GKE and Cloud SQL
+## 5. Setting Up Private Connectivity Between GKE and Cloud SQL
 
 ### Enable Service Networking API
 
@@ -226,7 +221,7 @@ $ gcloud sql instances describe <INSTANCE-NAME> \
   --project=<PROJECT-ID>
 ```
 
-## 7. Deploy Keycloak on GKE with Cloud SQL
+## 6. Deploy Keycloak on GKE with Cloud SQL
 
 Follow the [Keycloak deployment guide for GCP GKE](https://github.com/microcks/community/blob/main/install/gcp/keycloak-installation.md) provided by the Microcks community.
 
@@ -238,118 +233,265 @@ Once Keycloak is successfully deployed, complete the following configuration:
 - **Set up a `microcks` client** within that realm.
 - **Add a `microcks` user** and assign appropriate roles for accessing the Microcks dashboard.
 
+## 7. Deploy External MongoDB on GKE
 
-## 8 Deploy Microcks on GKE
+### Add Bitnami Helm Chart Repository and Install MongoDB
 
-### Add Microcks Helm Repository
+```sh
+$ helm repo add bitnami https://charts.bitnami.com/bitnami
+
+$ helm install mongodb bitnami/mongodb -n microcks \
+  --set architecture=standalone \
+  --set persistence.enabled=true \
+  --set persistence.size=10Gi \
+  --set persistence.storageClass=standard \
+  --set resources.requests.cpu=500m \
+  --set resources.requests.memory=1Gi \
+  --set resources.limits.cpu=1 \
+  --set resources.limits.memory=2Gi \
+  --set auth.enabled=true \
+  --set auth.rootPassword=<ROOT_PASSWORD> \
+  --set auth.username=<USERNAME> \
+  --set auth.password=<PASSWORD> \
+  --set auth.database=<DATABASE>
+```
+
+### Verify MongoDB Deployment
+
+```sh
+$ kubectl get pods -n microcks
+--- OUTPUT ---
+NAME                                        READY   STATUS    RESTARTS        AGE
+keycloak-0                                  1/1     Running   0               1d2h
+mongodb-69d8b98df-q5vl2                     1/1     Running   0               2m
+```
+
+### Create the MongoDB Connection Secret
+
+```sh
+$ kubectl create secret generic microcks-mongodb-connection -n microcks \
+  --from-literal=username=<USERNAME> \
+  --from-literal=password=<PASSWORD>
+```
+
+## 8. Deploy Microcks on GKE with Default Options
+
+### Add the Microcks Helm repository
+
 ```sh
 $ helm repo add microcks https://microcks.io/helm
 $ helm repo update
 ```
 
-### Prepare `microcks.yaml` Configuration File
+> **Note:** Make sure you've followed the steps to deploy Keycloak, installed NGINX Ingress Controller, configured cert-manager for SSL certificates, and created a ClusterIssuer.
+
+### Prepare microcks.yaml Configuration File
+Create the microcks.yaml file with the configuration below. Replace the placeholders like YOUR-DOMAIN, USERNAME, and PASSWORD with your actual values.
+
 ```sh
 $ cat > microcks.yaml <<EOF
+appName: microcks
+ingresses: true
+
 microcks:
-  url: "microcks.autoip.nip.io"
-  resources: {}
-
-service:
-  type: LoadBalancer
-  port: 8080
-  annotations:
-    cloud.google.com/load-balancer-type: "External"
-
-grpc:
-  enabled: true
-  service:
-    type: LoadBalancer
-    port: 9090
-    annotations:
-      cloud.google.com/load-balancer-type: "External"
-
-mongodb:
-  enabled: false
-  persistence:
-    enabled: false
+  url: microcks.<YOUR-DOMAIN>.com
+  ingressClassName: nginx
+  ingressAnnotations:
+    cert-manager.io/cluster-issuer: "letsencrypt-prod"
+    nginx.ingress.kubernetes.io/proxy-body-size: "50m"
+   
+  grpcEnableTLS: true
+  grpcIngressClassName: nginx
+  grpcIngressAnnotations:
+    cert-manager.io/cluster-issuer: "letsencrypt-prod"
+    nginx.ingress.kubernetes.io/backend-protocol: "GRPC"
+    nginx.ingress.kubernetes.io/ssl-passthrough: "true"
+    
+  env:
+    - name: SPRING_DATA_MONGODB_URI
+      value: "mongodb://<USERNAME>:<PASSWORD>@mongodb.microcks.svc.cluster.local:27017/microcks?authSource=microcks"
+    - name: CORS_REST_ALLOWED_ORIGINS
+      value: "https://keycloak.<YOUR-DOMAIN>.com"
+    - name: CORS_REST_ALLOW_CREDENTIALS
+      value: "true"    
 
 keycloak:
-  enabled: false  
-  postgresql:
-    enabled: false 
-
-identity:
-  provider: keycloak
-  keycloak:
-    url: "http://keycloak.<KEYCLOAK-EXTERNAL-IP>.nip.io" 
-    realm: "<YOUR-REALM-NAME>"
-    clientId: "<YOUR-CLIENT-ID>"
-    clientSecret: "<CLIENT-SECRET>"
-
-postman:
   enabled: true
-  resources: {}
+  install: false
+  url: keycloak.<YOUR-DOMAIN>.com
+  privateUrl: https://keycloak.<YOUR-DOMAIN>.com
+  realm: microcks
+  client:
+    id: <YOUR-CLIENT-ID>  
+    secret: <CLIENT-SECRET>
 
-env:
-  - name: MICROCKS_APP_STORAGE_TYPE
-    value: "firestore"
-  - name: GCP_PROJECT_ID
-    value: "<GCP-PROJECT-ID>"
+mongodb:
+  install: false  
+  database: microcks
+  secretRef:
+    secret: microcks-mongodb-connection
+    usernameKey: username
+    passwordKey: password
+    
+ingress:
+  enabled: true
+  tls: true
 EOF
 ```
 
-### Install Microcks on GKE
+### Deploy Microcks
+
 ```sh
 $ helm install microcks microcks/microcks -n microcks --create-namespace -f microcks.yaml
 ```
 
-### Verify Deployment and Check Pod Status
+### Verify Pod Status
+
 ```sh
 $ kubectl get pods -n microcks
-$ kubectl describe pod <POD-NAME> -n microcks
+--- OUTPUT ---
+NAME                                        READY   STATUS    RESTARTS        AGE
+keycloak-0                                  1/1     Running   0               2h8m
+microcks-5dcc6b6c8c-wxrr6                   1/1     Running   0               3m2s
+microcks-postman-runtime-76c4c86775-v66mb   1/1     Running   0               2m4s
+mongodb-69d8b98df-q5vl2                     1/1     Running   0               1h2m
 ```
 
-### Get External IPs for Microcks and gRPC
+### Get Microcks Ingress and Access URL
+
 ```sh
-$ kubectl get svc -n microcks
+$ kubectl get ingress -n microcks
+--- OUTPUT ---
+NAME            CLASS   HOSTS                                 ADDRESS         PORTS     AGE
+keycloak        nginx   keycloak.<YOUR-DOMAIN>.com            <INGRESS-IP>    80, 443   2h9m
+microcks        nginx   microcks.<YOUR-DOMAIN>.com            <INGRESS-IP>    80, 443   3m17s
+microcks-grpc   nginx   microcks-grpc.<YOUR-DOMAIN>.com       <INGRESS-IP>    80, 443   3m17s
 ```
+Microcks is available at: `https://microcks.<YOUR-DOMAIN>.com` gRPC mock service is available at: `microcks-grpc.<YOUR-DOMAIN>.com`
 
-### Update Keycloak Configuration
-#### Login to Keycloak and Navigate to Client Configuration
-1. Select **Realm Settings** → `microcks`
-2. Go to **Clients** → `microcks-app`
+🎉 **Congratulations! You have successfully deployed Microcks on GKE with default options. Now, you can start using Microcks to mock and test your APIs seamlessly in your cloud environment.**
 
-### Update Security Settings
-```yaml
-Valid Redirect URIs:
-  http://microcks.<MICROCKS-EXTERNAL-IP>.nip.io/*
-  http://microcks-grpc.<GRPC-EXTERNAL-IP>.nip.io/*
 
-Web Origins:
-  http://microcks.<MICROCKS-EXTERNAL-IP>.nip.io
-  http://microcks-grpc.<GRPC-EXTERNAL-IP>.nip.io
-```
+## 9. Deploy Microcks on GKE with Asynchronous Options
 
-### Upgrade Helm Configuration
-#### Using nip.io
+### Add the Microcks Helm repository
+
 ```sh
-$ helm upgrade microcks microcks/microcks -n microcks \
-  --set microcks.url=microcks.<MICROCKS-EXTERNAL-IP>.nip.io \
-  --set grpc.host=microcks-grpc.<GRPC-EXTERNAL-IP>.nip.io
+$ helm repo add microcks https://microcks.io/helm
+$ helm repo update
 ```
 
-#### Using a Custom Domain
-If you have a custom domain, update your DNS provider to create an `A` record pointing to the external IP of Microcks.
+> **Note:** Make sure you've followed the steps to deploy Keycloak, installed NGINX Ingress Controller, configured cert-manager for SSL certificates, and created a ClusterIssuer.
+
+### Enable SSL Passthrough on NGINX Ingress Controller
+
 ```sh
-$ helm upgrade microcks microcks/microcks -n microcks \
-  --set microcks.url=microcks.<your-custom-domain.com> \
-  --set grpc.host=microcks-grpc.<your-custom-domain.com>
+$ kubectl patch -n ingress-nginx deployment/ingress-nginx-controller --type='json' \
+  -p '[{"op":"add","path":"/spec/template/spec/containers/0/args/-","value":"--enable-ssl-passthrough"}]'
 ```
-Ensure your domain's DNS settings correctly map to the external IP of your Microcks service by creating an **A Record** in your DNS provider.
 
-### Access URLs:
-- **Microcks UI:** `http://microcks.<MICROCKS-EXTERNAL-IP>.nip.io`
-- **gRPC:** `http://microcks-grpc.<GRPC-EXTERNAL-IP>.nip.io`
+###  Install Strimzi Operator for Kafka Support
 
-🎉 **Congratulations! You have successfully deployed Microcks on GKE. Now, you can start using Microcks to mock and test your APIs seamlessly in your cloud environment.**
+```sh
+$ kubectl apply -f 'https://strimzi.io/install/latest?namespace=microcks' -n microcks
+```
 
+### Prepare microcks.yaml Configuration File
+Create the microcks-kafka.yaml file with the configuration below. Replace the placeholders like YOUR-DOMAIN, USERNAME, and PASSWORD with your actual values.
+
+
+```sh
+$ cat > microcks-kafka.yaml <<EOF
+appName: microcks
+ingresses: true
+
+microcks:
+  url: microcks.<YOUR-DOMAIN>.com
+  ingressClassName: nginx
+  ingressAnnotations:
+    cert-manager.io/cluster-issuer: "letsencrypt-prod"
+    nginx.ingress.kubernetes.io/proxy-body-size: "50m"
+
+  grpcEnableTLS: true
+  grpcIngressClassName: nginx
+  grpcIngressAnnotations:
+    cert-manager.io/cluster-issuer: "letsencrypt-prod"
+    nginx.ingress.kubernetes.io/backend-protocol: "GRPC"
+    nginx.ingress.kubernetes.io/ssl-passthrough: "true"
+    
+  env:
+    - name: SPRING_DATA_MONGODB_URI
+      value: "mongodb://<USERNAME>:<PASSWORD>@mongodb.microcks.svc.cluster.local:27017/microcks?authSource=microcks"
+    - name: CORS_REST_ALLOWED_ORIGINS
+      value: "https://keycloak.<YOUR-DOMAIN>.com"
+    - name: CORS_REST_ALLOW_CREDENTIALS
+      value: "true"    
+
+keycloak:
+  enabled: true
+  install: false
+  url: keycloak.<YOUR-DOMAIN>.com
+  privateUrl: https://keycloak.<YOUR-DOMAIN>.com
+  realm: microcks
+  client:
+    id: <YOUR-CLIENT-ID>  
+    secret: <CLIENT-SECRET>
+
+mongodb:
+  install: false  
+  database: microcks
+  secretRef:
+    secret: microcks-mongodb-connection
+    usernameKey: username
+    passwordKey: password
+
+features:
+  async:
+    enabled: true
+    kafka:
+      install: true
+      url: kafka.<YOUR-DOMAIN>.com
+      ingressClassName: nginx
+      ingressAnnotations:
+        cert-manager.io/cluster-issuer: "letsencrypt-prod"
+        nginx.ingress.kubernetes.io/proxy-body-size: "50m"
+        nginx.ingress.kubernetes.io/ssl-passthrough: "true"
+    
+ingress:
+  enabled: true
+  tls: true
+EOF
+```
+
+### Deploy Microcks with Kafka
+
+```sh
+$ helm install microcks microcks/microcks -n microcks --create-namespace -f microcks-kafka.yaml
+```
+
+### Verify Pod Status
+
+```sh
+$ kubectl get pods -n microcks
+--- OUTPUT ---
+NAME                                              READY   STATUS    RESTARTS       AGE
+keycloak-0                                        1/1     Running   0              1h2m
+microcks-65dfc96686-bl5lv                         1/1     Running   0              99s
+microcks-async-minion-5c8cc4d4db-ttbst            1/1     Running   3 (62s ago)    99s
+microcks-kafka-entity-operator-79c49b679b-xkssp   1/2     Running   0              19s
+microcks-kafka-kafka-0                            1/1     Running   0              51s
+microcks-kafka-zookeeper-0                        1/1     Running   0              95s
+microcks-postman-runtime-5fffb86666-bx74t         1/1     Running   0              99s
+mongodb-69d8b98df-q5vl2                           1/1     Running   0              6h3m
+strimzi-cluster-operator-6bf566db79-bdjd8         1/1     Running   1 (7d1h ago)   4m2m
+```
+
+### Get the Ingress details for Microcks and Kafka.
+
+```sh
+$ kubectl get ingress -n microcks
+```
+
+Microcks is available at: `https://microcks.<YOUR-DOMAIN>.com` gRPC mock service is available at: `microcks-grpc.<YOUR-DOMAIN>.com` Kafka broker is available at: `microcks-kafka.kafka.<YOUR-DOMAIN>.com`
+
+🎉 **Congratulations! You have successfully deployed Microcks on GKE with asynchronous options. Now, you can start using Microcks to mock and test your APIs, with enhanced asynchronous capabilities, in your cloud environment.**


### PR DESCRIPTION
This PR enhances the existing Microcks GKE deployment documentation by addressing key production-readiness features:

**Adding Asynchronous Protocol Support**
- Enables Kafka-based async protocols using `features.async.enabled=true` in Helm.
- Adds steps to install Strimzi and patch the NGINX Ingress Controller for SSL passthrough.

 **Switching to External MongoDB**
- Adds steps for deploying and connecting an external MongoDB instance.
- Replaces Firestore, as it is not fully compatible with Microcks, which requires MongoDB.

**Securing Microcks Endpoint with TLS**
- Adds cert-manager installation and creation of a Let's Encrypt `ClusterIssuer`.
- Configures Ingress annotations for automatic certificate provisioning and TLS termination.

**Clarifying Required Permissions**
- Adds notes on obtaining required IAM roles and permissions from a GCP admin user.

Fixes: #63 
Part of #32 
