### PR TITLE
🐛 fix: update broken console-kb link (solutions/ → fixes/)

### DIFF
--- a/install/kubestellar-console/README.md
+++ b/install/kubestellar-console/README.md
@@ -91,7 +91,7 @@ Each mission walks through diagnosis, fix, and verification steps with commands 
 
 ## Mission Source
 
-The mission definition is an open-source JSON file in the [console-kb](https://github.com/kubestellar/console-kb/blob/master/solutions/cncf-install/install-microcks.json?utm_source=github&utm_medium=pr&utm_campaign=cncf_outreach&utm_term=microcks) repository. PRs to improve the Microcks mission steps, add validation checks, or update versions are welcome.
+The mission definition is an open-source JSON file in the [console-kb](https://github.com/kubestellar/console-kb/blob/master/fixes/cncf-install/install-microcks.json?utm_source=github&utm_medium=pr&utm_campaign=cncf_outreach&utm_term=microcks) repository. PRs to improve the Microcks mission steps, add validation checks, or update versions are welcome.
 
 ## References
 


### PR DESCRIPTION
## Summary
- Fix broken link in `install/kubestellar-console/README.md` — the `console-kb` repo renamed `solutions/` to `fixes/` in [kubestellar/console-kb#182](https://github.com/kubestellar/console-kb/pull/182)

## Test plan
- [x] Verify [the corrected link](https://github.com/kubestellar/console-kb/blob/master/fixes/cncf-install/install-microcks.json) resolves (200)
- [x] Verify the old `solutions/` link returns 404